### PR TITLE
fixing assets path with assets_version enabled

### DIFF
--- a/Twig/Extension/UploaderExtension.php
+++ b/Twig/Extension/UploaderExtension.php
@@ -83,7 +83,7 @@ class UploaderExtension extends \Twig_Extension
             
             $urlParts = parse_url($path);
             $pathPart = $urlParts['path'];
-            $queryPart = isset($urlParts['query'])===true?$urlParts['query']:'';
+            $queryPart = isset($urlParts['query'])===true?'?'.$urlParts['query']:'';
             
             echo sprintf('<link href="%s/css/doc.css%s" media="all" rel="stylesheet" type="text/css" />', $pathPart, $queryPart);
             echo sprintf('<script src="%s/js/external/ajaxupload/ajaxupload.min.js%s" type="text/javascript"></script>', $pathPart, $queryPart);

--- a/Twig/Extension/UploaderExtension.php
+++ b/Twig/Extension/UploaderExtension.php
@@ -80,10 +80,14 @@ class UploaderExtension extends \Twig_Extension
             $path = $this->environment
                 ->getExtension('assets')
                 ->getAssetUrl($this->basePath);
-
-            echo sprintf('<link href="%s/css/doc.css" media="all" rel="stylesheet" type="text/css" />', $path);
-            echo sprintf('<script src="%s/js/external/ajaxupload/ajaxupload.min.js" type="text/javascript"></script>', $path);
-            echo sprintf('<script src="%s/js/application.js" type="text/javascript"></script>', $path);
+            
+            $urlParts = parse_url($path);
+            $pathPart = $urlParts['path'];
+            $queryPart = isset($urlParts['query'])===true?$urlParts['query']:'';
+            
+            echo sprintf('<link href="%s/css/doc.css%s" media="all" rel="stylesheet" type="text/css" />', $pathPart, $queryPart);
+            echo sprintf('<script src="%s/js/external/ajaxupload/ajaxupload.min.js%s" type="text/javascript"></script>', $pathPart, $queryPart);
+            echo sprintf('<script src="%s/js/application.js" type="text/javascript%s"></script>', $pathPart, $queryPart);
 
             $this->autoInclude = false;
         }


### PR DESCRIPTION
There was a problem in printing assets path in case [assets_version](http://symfony.com/doc/current/reference/configuration/framework.html#ref-framework-assets-version) option - which is used in cache busting - is enabled for twig.

Current bug cause addAssets() methods to print out incorrect url in this case, ex.

    http://localhost:8000/bundles/ewzuploader?v=1.0.12/js/external/ajaxupload/ajaxupload.min.js&_=1438727268215
check attached screenshot.

with this pull request the URLs are printed correctly, ex.

    http://localhost:8000/bundles/ewzuploader/js/external/ajaxupload/ajaxupload.min.js?v=1.0.12&_=1438727414856

![ewzuploader issue](https://cloud.githubusercontent.com/assets/5447528/9074372/98e4f6ee-3b11-11e5-8c16-78c28b5f1c1f.png)
